### PR TITLE
Fixes bug introduced by zoom to extents.

### DIFF
--- a/app/js/mol.core.js
+++ b/app/js/mol.core.js
@@ -12,49 +12,8 @@ mol.modules.core = function(mol) {
         var name = $.trim(layer.name.toLowerCase()).replace(/ /g, "_"),
             type = $.trim(layer.type.toLowerCase()).replace(/ /g, "_"),
             source = $.trim(layer.source.toLowerCase()).replace(/,/g, "").replace(/ /g, "_"),
-            type_title = $.trim(layer.type_title).replace(/,/g, "").replace(/ /g, "_"),
-            source_title = $.trim(layer.source_title).replace(/,/g, "").replace(/ /g, "_"),
-            names = $.trim(layer.names).replace(/'S/g, "'s").replace(/ /g, "_"),
-            feature_count = $.trim(layer.feature_count).replace(/ /g, "_"),
-            sourcetype =  $.trim(layer.sourcetype).replace(/ /g, "_"),
-            _class = $.trim(layer._class).replace(/ /g, "_"),
-            extent = $.trim(layer.extent).replace(/ /g, "_").replace(/{/g,'lsq').replace(/}/g,'rsq'); //replacing squiggly brackets with lsq and rsq to make the json DOM-id-friendly.
-        return 'layer--{0}--{1}--{2}--{3}--{4}--{5}--{6}--{7}--{8}--{9}'.format(name, type, source, names, feature_count, type_title, source_title, sourcetype, _class, extent);
+            data_table = $.trim(layer.data_table).replace(/,/g, "").replace(/ /g, "_");
+
+        return 'layer--{0}--{1}--{2}--{3}'.format(name, type, source, data_table);
     };
-
-    /**
-     * @param id The layer id of the form "layer--{name}--{type}--{source}--{englishname}".
-     */
-    mol.core.getLayerFromId = function(id) {
-        var tokens = id.split('--'),
-            name = tokens[1].replace(/_/g, " "),
-            type = tokens[2].replace(/_/g, " "),
-            source = tokens[3].replace(/_/g, " "),
-            names = tokens[4].replace(/_/g, " "),
-            feature_count = tokens[5].replace(/_/g, " "),
-            type_title = tokens[6].replace(/_/g, " "),
-            source_title = tokens[7].replace(/_/g, " "),
-            sourcetype = tokens[8].replace(/_/g, " "),
-            _class = tokens[9].replace(/_/g, " "),
-            extent = tokens[10].replace(/_/g, " ").replace(/lsq/g,'{').replace(/rsq/g,'}'); //put brackets back in to json.
-
-        name = name.charAt(0).toUpperCase()+name.slice(1).toLowerCase();
-        source = source.toLowerCase();
-        type = type.toLowerCase();
-        _class = _class.toLowerCase();
-
-        return {
-            id: id,
-            name: name,
-            type: type,
-            source: source,
-            names: names,
-            feature_count: feature_count,
-            type_title: type_title,
-            source_title: source_title,
-            sourcetype: sourcetype,
-            _class : _class,
-            extent: extent
-        };
-    };
-};
+}

--- a/app/js/mol.map.results.js
+++ b/app/js/mol.map.results.js
@@ -65,8 +65,7 @@ mol.modules.map.results = function(mol) {
                         layers = _.map(
                             checkedResults,
                             function(result) {
-                                var id = $(result).find('.result').attr('id');
-                                return mol.core.getLayerFromId(id);
+                                return $.data(result[0],"layer");
                             }
                         );
                         if(self.map.overlayMapTypes.length + layers.length > 100) {
@@ -175,14 +174,14 @@ mol.modules.map.results = function(mol) {
                     // TODO: Wire up results.
                         result.source.click(
                             function(event) {
-                                self.bus.fireEvent(new mol.bus.Event('metadata-toggle', {params : { type: result.layerObj.type, provider: result.layerObj.source, _class: result.layerObj._class, name: result.layerObj.name }}));
+                                self.bus.fireEvent(new mol.bus.Event('metadata-toggle', {params : { type: $.data(result[0],'layer').type, provider: $.data(result[0],'layer').source, _class: $.data(result[0],'layer')._class, name: $.data(result[0],'layer').name }}));
                                 event.stopPropagation();
                                 event.cancelBubble = true;
                             }
                         );
                         result.type.click(
                             function(event) {
-                                self.bus.fireEvent(new mol.bus.Event('metadata-toggle', {params : { type: result.layerObj.type}}));
+                                self.bus.fireEvent(new mol.bus.Event('metadata-toggle', {params : { type: $.data(result[0],'layer').type}}));
                                 event.stopPropagation();
                                 event.cancelBubble = true;
                             }
@@ -394,17 +393,7 @@ mol.modules.map.results = function(mol) {
                 return _.map(
                     layers,
                     function(layer) {
-                        var id = layer.id,
-                            name = layer.name,
-                            source = layer.source,
-                            type = layer.type,
-                            names = layer.names,
-                            feature_count = layer.feature_count,
-                            type_title = layer.type_title,
-                            source_title = layer.source_title,
-                            sourcetype = layer.sourcetype,
-                            result = new mol.map.results.ResultDisplay(name, id, source, type, names, feature_count, type_title, source_title, sourcetype);
-                            result.layerObj = layer;
+                        var result = new mol.map.results.ResultDisplay(layer);
                         this.resultList.append(result);
                         return result;
                     },
@@ -470,7 +459,7 @@ mol.modules.map.results = function(mol) {
      */
     mol.map.results.ResultDisplay = mol.mvp.View.extend(
         {
-            init: function(name, id, source, type, names, feature_count, type_title, source_title) {
+            init: function(layer) {
                 var self=this, html = '' +
                     '<div>' +
                     '<ul id="{0}" class="result">' +
@@ -490,15 +479,13 @@ mol.modules.map.results = function(mol) {
                     '<div class="break"></div>' +
                     '</div>';
 
-                this._super(html.format(id, name, source, type, names, feature_count, type_title, source_title));
-
+                this._super(html.format(layer.id, layer.name, layer.source, layer.type, layer.names, layer.feature_count, layer.type_title, layer.source_title));
+                $.data(this[0],'layer',layer);
                 this.infoLink = $(this).find('.info');
                 this.nameBox = $(this).find('.resultName');
                 this.source = $(this).find('.source');
                 this.type = $(this).find('.type');
                 this.checkbox = $(this).find('.checkbox');
-                //this.customCheck = $(this).find('.customCheck');
-
             }
         }
     );

--- a/app/js/mol.services.cartodb.js
+++ b/app/js/mol.services.cartodb.js
@@ -287,19 +287,7 @@ mol.modules.services.cartodb = function(mol) {
                 for (i in rows) {
                     row = rows[i];
                     key = i + '';
-                    layers[key] = {
-                        name: row.name.charAt(0).toUpperCase()+row.name.slice(1).toLowerCase(),
-                        source: row.source.toLowerCase(),
-                        type: row.type.toLowerCase(),
-                        // This removes duplicates:
-                        names: (row.names != undefined) ? _.uniq(row.names.split(', ')).join(', ') : '',
-                        feature_count: row.feature_count,
-                        type_title: row.type_title,
-                        source_title: row.source_title,
-                        sourcetype : row.sourcetype,
-                        _class: row._class,
-                        extent: row.extent
-                    };
+                    layers[key] = row;
                 }
                 return layers;
             },


### PR DESCRIPTION
Layers weren't adding right because the extents json was getting passed along in a DOM ID with various other layer metadata. It was a mess. Now using jquery data() to pass along layer state in results widget instead, with a nice and tidy unique ID field for each layer.
