### PR TITLE
Feature/press page lite

### DIFF
--- a/app/css/homepage.css
+++ b/app/css/homepage.css
@@ -412,6 +412,11 @@ div#content .wrapper .details{
     color: #fff;
     height: 140px;
 }
+div#content .wrapper #fill .details {
+    height: auto;
+    margin-bottom: 20px;
+}
+
 div#content .wrapper .details .pretitle{ 
     font-style: italic;
     color: #ccc;
@@ -438,6 +443,18 @@ div#content .recent_updates a {
     color: #B8FD82;
 }
 
+div#content .wrapper #fill { 
+    margin-top: 20px;
+    float: left;
+    width: 785px;
+    padding: 5px;
+    background-color: rgba(33,33,33,0.2); 
+    color: #111; 
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+    overflow-y: hidden;
+}
+
 div#content .wrapper #left{ 
     float: left;
     width: 495px;
@@ -455,6 +472,12 @@ div#content .wrapper #blog{
 div#content .wrapper #blog a{ 
     color: #b8fd85;
 }
+
+/* The "all entries" link at the bottom. */
+div#content .wrapper .all_entries a { 
+    color: #b8fd85;
+}
+
 div#content .wrapper #right{ 
     float: left;
     width: 260px;
@@ -466,6 +489,15 @@ div#content .wrapper #right{
     border-radius: 10px;
     overflow-y: hidden;
 }
+div#content .wrapper #press { 
+    height: 285px;
+    color: #fff;
+    overflow: hidden;
+}
+div#content .wrapper #press a{ 
+    color: #b8fd85;
+}
+
 div#content .wrapper #code{ 
     height: 285px;
     color: #fff;
@@ -474,6 +506,7 @@ div#content .wrapper #code{
 div#content .wrapper #code a{ 
     color: #b8fd85;
 }
+
 div#footer {float: left; position: relative; width: 800px; left: 50%; margin-left: -690px; margin-bottom: 0px; height: 40px;}
 div#footer #footer_links { float: right; width: 500px; text-align: left; margin-right: 10px; height: auto; color: #fff; }
 div#footer #footer_links a { font-size: 1.1em; color: #aaa; padding-right: 8px; padding-left: 8px; line-height: 150%; text-decoration: underline;}

--- a/app/css/homepage.css
+++ b/app/css/homepage.css
@@ -474,6 +474,11 @@ div#content .wrapper #blog a{
 }
 
 /* The "all entries" link at the bottom. */
+div#content .wrapper .all_entries {
+    padding: 5px;
+    padding-top: 10px;
+}
+
 div#content .wrapper .all_entries a { 
     color: #b8fd85;
 }

--- a/app/templates/homepage/home.html
+++ b/app/templates/homepage/home.html
@@ -136,7 +136,12 @@
                                 <div class="pretitle">HIGHLIGHT</div>
                                 <div class="title">MAP OF LIFE BLOG</div>
                                 <div class="description">
-                                The MOL team is rapidly developing many features and new technologies. We are also rapidly increasing the number of species distribution datasets we make available.  As we roll out new datasetss and features, you can follow our blog to learn what we are up to and provide valuable feedback and insight into the work we are doing.
+                                The MOL team is rapidly developing many features and 
+                                new technologies. We are also rapidly increasing the 
+                                number of species distribution datasets we make available. 
+                                As we roll out new datasetss and features, you can follow 
+                                our blog to learn what we are up to and provide valuable 
+                                feedback and insight into the work we are doing.
                                 </div>
                             </div>
                             <!--

--- a/app/templates/homepage/home.html
+++ b/app/templates/homepage/home.html
@@ -62,17 +62,23 @@
                         }
                     },8000);
                 });
-                
+
                 $('#blog').gFeed({ 
-                    url: 'http://mappinglife.wordpress.com/feed/',
+                    url: 'http://mappinglife.wordpress.com/feed?cat=-2764',
+                    tabs: false,
+                    max: 4
+                }); 
+                $('#press').gFeed({ 
+                    url: 'http://mappinglife.wordpress.com/category/Press/feed/',
                     tabs: false,
                     max: 4
                 }); 
                 $('#code').gFeed({ 
                     url: 'https://github.com/mapoflife/MOL/commits/develop.atom',
                     tabs: false,
-                    max: 4
+                    max: 5
                 }); 
+
             });
         </script>
         <script type="text/javascript">
@@ -125,15 +131,12 @@
                 <div id="content">
                     <div class="wrapper">
                         <div id="left">
+
                             <div class="details">
                                 <div class="pretitle">HIGHLIGHT</div>
                                 <div class="title">MAP OF LIFE BLOG</div>
                                 <div class="description">
-                                    The MOL team is rapidly developing many features and 
-                                    new technologies. While we are not ready to roll out 
-                                    all the features, you can follow our blog to learn 
-                                    what we are up to and provide valuable feedback and 
-                                    insights into the work we are doing.
+                                The MOL team is rapidly developing many features and new technologies. We are also rapidly increasing the number of species distribution datasets we make available.  As we roll out new datasetss and features, you can follow our blog to learn what we are up to and provide valuable feedback and insight into the work we are doing.
                                 </div>
                             </div>
                             <!--
@@ -143,8 +146,23 @@
                             </div>
                             -->
                             <div id="blog"></div>
+                            <div class="all_entries" align="right"><a href="http://mappinglife.wordpress.com/?cat=-2764">All blog posts</a></div>
                         </div>
                         <div id="right">
+                            <div class="details">
+                                <div class="pretitle">HIGHLIGHT</div>
+                                <div class="title">PRESS</div>
+                                <div class="description">
+                                    Map of Life has been covered by newspapers, magazines
+                                    and blogs from around the world. Here are a few selected
+                                    quotes from their articles.
+                                </div>
+                            </div>
+                            <div id="press"></div>
+                            <div class="all_entries" align="right"><a href="http://mappinglife.wordpress.com/category/press">All press articles</a></div>
+                        </div>
+
+                        <div id="fill">
                             <div class="details">
                                 <div class="pretitle">HIGHLIGHT</div>
                                 <div class="title">CODE DEVELOPMENT</div>
@@ -155,6 +173,7 @@
                                 </div>
                             </div>
                             <div id="code"></div>
+                            <div class="all_entries" align="right"><a href="https://github.com/MapofLife/MOL">All recent changes</a></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Update the about-us page (http://www.mappinglife.org/about/) so that it contains both blog posts and news articles, as well as the existing Github updates. This is supposed to be a stop-gap before we go to the full press page (as coded at feature/press-page) or we completely redesign the about-us pages.
