### PR TITLE
Search scientific names differently from vernacular names

### DIFF
--- a/app/js/mol.map.search.js
+++ b/app/js/mol.map.search.js
@@ -69,7 +69,7 @@ mol.modules.map.search = function(mol) {
                 'LEFT JOIN ac n ON ' +
                     'l.scientificname = n.n ' +
                 'WHERE ' +
-                     "n.n~*'\\m{0}' OR n.v~*'\\m{0}' " +
+                     "n.n~*'^\\m{0}' OR n.v~*'\\m{0}' " +
                 'ORDER BY name, type_sort_order';
         },
 

--- a/app/static/js/mol.js
+++ b/app/static/js/mol.js
@@ -2853,7 +2853,7 @@ mol.modules.map.search = function(mol) {
                 'LEFT JOIN ac n ON ' +
                     'l.scientificname = n.n ' +
                 'WHERE ' +
-                     "n.n~*'\\m{0}' OR n.v~*'\\m{0}' " +
+                     "n.n~*'^\\m{0}' OR n.v~*'\\m{0}' " +
                 'ORDER BY name, type_sort_order';
         },
 


### PR DESCRIPTION
This modification will prevent searches from matching scientific searches to species epithets. Searching for "tigris" will continue to match "Tigrisoma fasciatum" but will no longer match "Panthera tigris". Vernacular search is unchanged: "tiger" will still match the "Flamed Tigersnail", "Big Sand Tiger Beetle" and "Tiger Orchid". Autocomplete searches remain unchanged; this is a change in the layer search only. This addresses the first issue raised by Walter here: https://basecamp.com/1756489/projects/1391223-new-datasets/messages/12549329-name-validation#comment_105472043
